### PR TITLE
needing to refresh apt cache for testing the role

### DIFF
--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -1,5 +1,8 @@
 ---
 
+- name: packages | update apt cache
+  apt: update_cache=yes
+
 - name: packages | install
   apt:
     pkg: "{{ item }}"


### PR DESCRIPTION
I started testing your nagios roles and had a problem at the first execution everytime I newly created a VM for the test. It is because the `tasks/package.yml` presumes that `apt-get update` has been executed at least once before running this role. So basically, this change is only needed to make it possible to test these roles, but I believe it is good to make it testable.
