### PR TITLE
add initial testing setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+
+FROM phusion/baseimage:0.9.17
+
+RUN apt-get update
+RUN apt-get -y install python-dev python-pip httpie
+RUN pip install jinja2 ansible
+
+RUN mkdir -p /test/roles/nagios_server
+ADD defaults /test/roles/nagios_server/defaults
+ADD files /test/roles/nagios_server/files
+ADD handlers /test/roles/nagios_server/handlers
+ADD tasks /test/roles/nagios_server/tasks
+ADD templates /test/roles/nagios_server/templates
+ADD test /test/
+
+WORKDIR /test
+ENTRYPOINT ./run.sh

--- a/runtest.sh
+++ b/runtest.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -xe
+
+name=$(basename $PWD)
+sudo docker build -t $name .
+sudo docker run --rm -t -i $name

--- a/test/ansible.cfg
+++ b/test/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+inventory = inventory.txt

--- a/test/inventory.txt
+++ b/test/inventory.txt
@@ -1,0 +1,1 @@
+localhost ansible_connection=local

--- a/test/playbook.yml
+++ b/test/playbook.yml
@@ -1,0 +1,6 @@
+---
+
+- hosts: all
+  roles:
+
+    - role: nagios_server

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# This is intended to be run on the docker node
+
+PS4='$LINENO: '
+set -ex
+
+ansible-playbook playbook.yml
+nc -zv localhost 80
+http \
+    -a nagiosadmin:nagiosadmin \
+    --follow \
+    --check-status \
+    localhost/nagios


### PR DESCRIPTION
Provides testing infrastructure: use `$ ./runtest.sh` to execute.

This will build a docker image configured to test the role, and execute an example playbook.

Many CI services, like Travis, only provide outdated VM images (ubuntu 12.04) but are supporting container-based approaches.
